### PR TITLE
Fix Pan and Origin fix for camera

### DIFF
--- a/GLX/Camera.cs
+++ b/GLX/Camera.cs
@@ -47,8 +47,7 @@ namespace GLX
             {
                 if (Focus == CameraFocus.Center)
                 {
-                    pan = value - new Vector2(virtualResolutionRenderer.VirtualResolution.Width / 2,
-                        virtualResolutionRenderer.VirtualResolution.Height / 2);
+                    pan = value;
                 }
                 else
                 {
@@ -114,8 +113,8 @@ namespace GLX
                     if (value == CameraFocus.Center)
                     {
                         focus = value;
-                        Origin = new Vector2(virtualResolutionRenderer.VirtualResolution.Width / 2,
-                            virtualResolutionRenderer.VirtualResolution.Height / 2);
+                        Origin = -(new Vector2(virtualResolutionRenderer.VirtualResolution.Width / 2,
+                            virtualResolutionRenderer.VirtualResolution.Height / 2));
                     }
                 }
                 else if (focus == CameraFocus.Center)
@@ -156,13 +155,10 @@ namespace GLX
 
             if (Focus == CameraFocus.Center)
             {
-                Vector3 reverseOriginTranslationVector = new Vector3(Origin, 0);
-                Matrix reverseOriginTranslationMatrix = Matrix.CreateTranslation(reverseOriginTranslationVector);
                 transform = cameraTranslationMatrix *
                     originTranslationMatrix *
                     cameraRotationMatrix *
                     cameraScaleMatrix *
-                    reverseOriginTranslationMatrix *
                     virtualResolutionRenderer.GetTransformationMatrix();
             }
             else if (Focus == CameraFocus.TopLeft)


### PR DESCRIPTION
When CameraFocus was set to Center, Pan was modified when you set it which is confusing because when you put in a value you expect to get the same value out. Instead leave Pan to whatever value was set and make sure Origin is changed correctly to focus the camera correctly when CameraFocus is changed.